### PR TITLE
fixing a small bug in setting aside threads for compression encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsra"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 license = "MIT"
 authors = ["Noam Teyssier <noam.teyssier@arcinstitute.org>"]

--- a/src/output.rs
+++ b/src/output.rs
@@ -99,7 +99,9 @@ pub fn build_writers(
             std::fs::create_dir(outdir)?;
         }
 
-        let c_threads = num_threads / 4;
+        // If four or more threads were allocated to `xsra`, use that number divided by four for
+        // compression. If fewer than four total threads were allocated, just set aside one thread.
+        let c_threads = (num_threads / 4).max(1);
         let mut writers = vec![];
         for i in 0..4 {
             let path = build_path_name(outdir, prefix, compression, format, i);


### PR DESCRIPTION
Hi Noam,

I have a project that involves mining potentially large amounts of reads from SRA on an HPC cluster. The whole process is sensitive to disk usage, so when I saw that `xsra` reduces the disk required to access reads through SRA's `.sra`-file indirection, I was eager to slot it in and give it a try.

In general, it has worked great, and I really appreciate the project (especially your going to the trouble of mapping out the `ncbi-vdb` library!). I only caught one small bug in my initial testing.`xsra` determines how many threads to assign to the compression writer by dividing the total threadcount by four, e.g.,:

```rust
// src/output.rs

let c_threads = num_threads / 4;
```

Because this is integer division, if the user requests less than 4 threads total, 0 threads will be assigned to compression, which is invalid and gives an "Invalid number of threads: (0)" error from the Gzip and Bgzip writer builders.

To fix this, I brought in `std::cmp::max`, like so:

```rust
// src/output.rs

// If four or more threads were allocated to `xsra`, use that number divided by four for
// compression. If fewer than four total threads were allocated, just set aside one thread.
let c_threads = (num_threads / 4).max(1);
```

Now, the minimum number of threads allocated to gzip will always be 1.

Thanks again for the project! I plan to continue using it and will reach out if I find any other edge cases.

--Nick