### PR TITLE
chore: add unit tests for remaining files

### DIFF
--- a/src/cli/recode.rs
+++ b/src/cli/recode.rs
@@ -111,9 +111,9 @@ fn parse_memory_size(input: &str) -> Result<usize, String> {
     let last_char = input.chars().last().unwrap_or('0');
 
     let (number_str, multiplier) = match last_char {
-        'K' | 'k' => (&input[..input.len() - 1], 1024),
-        'M' | 'm' => (&input[..input.len() - 1], 1024 * 1024),
-        'G' | 'g' => (&input[..input.len() - 1], 1024 * 1024 * 1024),
+        'K' => (&input[..input.len() - 1], 1024),
+        'M' => (&input[..input.len() - 1], 1024 * 1024),
+        'G' => (&input[..input.len() - 1], 1024 * 1024 * 1024),
         _ if last_char.is_ascii_digit() => (input.as_str(), 1),
         _ => return Err(format!("Invalid memory size format: {input}")),
     };
@@ -121,5 +121,41 @@ fn parse_memory_size(input: &str) -> Result<usize, String> {
     match number_str.parse::<usize>() {
         Ok(number) => Ok(number * multiplier),
         Err(_) => Err(format!("Failed to parse number: {number_str}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // parse_memory_size tests
+    #[test]
+    fn parse_memory_size_k_suffix() {
+        assert_eq!(parse_memory_size("1K"), Ok(1024));
+    }
+
+    #[test]
+    fn parse_memory_size_m_suffix() {
+        assert_eq!(parse_memory_size("1M"), Ok(1024 * 1024));
+    }
+
+    #[test]
+    fn parse_memory_size_g_suffix() {
+        assert_eq!(parse_memory_size("1G"), Ok(1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parse_memory_size_ascii_digit() {
+        assert_eq!(parse_memory_size("1024"), Ok(1024));
+    }
+
+    #[test]
+    fn parse_memory_size_invalid_format() {
+        assert!(parse_memory_size("512X").is_err());
+    }
+
+    #[test]
+    fn parse_memory_size_invalid_number() {
+        assert!(parse_memory_size("abcK").is_err());
     }
 }

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -85,3 +85,25 @@ pub fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    // describe_inner tests
+    #[test]
+    fn describe_inner_handles_invalid_sra_file() {
+        // Create an empty temporary file.
+        // This is not a valid SRA file.
+        let temp_sra = NamedTempFile::new().unwrap();
+        let path = temp_sra.path().to_str().unwrap();
+
+        let result = describe_inner(path, 0, 10);
+
+        assert!(
+            result.is_err(),
+            "describe_inner should fail when given a non-SRA file"
+        );
+    }
+}

--- a/src/dump/stats.rs
+++ b/src/dump/stats.rs
@@ -124,3 +124,101 @@ impl ProcessStatistics {
 fn sum_slice(vec: &[u64]) -> u64 {
     vec.iter().sum()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ProcessStatistics::add tests
+    #[test]
+    fn test_add_with_resize() {
+        let stats1 = ProcessStatistics {
+            num_spots: 10,
+            num_reads: 20,
+            reads_per_segment: vec![1, 2],
+            filter_size: vec![3, 4],
+            filter_type: vec![5, 6],
+        };
+        let stats2 = ProcessStatistics {
+            num_spots: 5,
+            num_reads: 10,
+            reads_per_segment: vec![1, 1, 1, 1],
+            filter_size: vec![2, 2, 2],
+            filter_type: vec![3, 3, 3, 3, 3],
+        };
+
+        let result = stats1.clone() + stats2.clone();
+
+        assert_eq!(result.num_spots, 15);
+        assert_eq!(result.num_reads, 30);
+        assert_eq!(result.reads_per_segment, vec![2, 3, 1, 1]);
+        assert_eq!(result.filter_size, vec![5, 6, 2]);
+        assert_eq!(result.filter_type, vec![8, 9, 3, 3, 3]);
+    }
+
+    #[test]
+    // ProcessStatistics::inc_spots tests
+    fn test_inc_spots() {
+        let mut stats = ProcessStatistics::default();
+        stats.inc_spots();
+        assert_eq!(stats.num_spots, 1);
+    }
+
+    #[test]
+
+    // ProcessStatistics::inc_reads tests
+    fn test_inc_reads_with_resize() {
+        let mut stats = ProcessStatistics::default();
+        // set seg_id > initial len of 4 to trigger resize
+        stats.inc_reads(5);
+        assert_eq!(stats.num_reads, 1);
+        assert_eq!(stats.reads_per_segment.len(), 6);
+        assert_eq!(stats.reads_per_segment[5], 1);
+    }
+
+    // ProcessStatistics::inc_filter_size tests
+    #[test]
+    fn test_inc_filter_size_with_resize() {
+        let mut stats = ProcessStatistics::default();
+        // set seg_id > initial len of 4 to trigger resize
+        stats.inc_filter_size(5);
+        assert_eq!(stats.filter_size.len(), 6);
+        assert_eq!(stats.filter_size[5], 1);
+    }
+
+    // ProcessStatistics::inc_filter_type tests
+    #[test]
+    fn test_inc_filter_type_with_resize() {
+        let mut stats = ProcessStatistics::default();
+        // set seg_id > initial len of 4 to trigger resize
+        stats.inc_filter_type(5);
+        assert_eq!(stats.filter_type.len(), 6);
+        assert_eq!(stats.filter_type[5], 1);
+    }
+
+    // ProcessStatistics::pprint tests
+    #[test]
+    fn test_pprint_with_all_data() {
+        let stats = ProcessStatistics {
+            num_spots: 100,
+            num_reads: 90,
+            reads_per_segment: vec![40, 50],
+            filter_size: vec![5, 0],
+            filter_type: vec![0, 5],
+        };
+
+        let mut buffer = Vec::new();
+        stats.pprint(&mut buffer).unwrap();
+        let output = String::from_utf8(buffer).unwrap();
+
+        assert!(output.contains("Number of spots processed: 100"));
+        assert!(output.contains("Number of reads written: 90"));
+        assert!(output.contains("Reads written per segment:"));
+        assert!(output.contains("  Segment 0: 40"));
+        assert!(output.contains("  Segment 1: 50"));
+        assert!(output.contains("Filtered reads by size:"));
+        assert!(output.contains("  Segment 0: 5"));
+        assert!(output.contains("Filtered reads by type:"));
+        assert!(output.contains("  Segment 1: 5"));
+    }
+}


### PR DESCRIPTION
Hi @noamteyssier, I added unit tests for the remaining files I thought needed them.

I also removed one minor code redundancy in `src/cli/recode`

I plan on adding integration tests for the following files/functions in the next PR:
- `src/dump/mod.rs` (`dump` end-to-end command)
- `src/dump/utils.rs` (`write_segment_to_buffer_set`, `write_fastq`, `write_fasta`)
- src/recode/mod.rs (`recode` end-to-end command covering `recode_to_binseq` and `recode_to_vbinseq)`
- src/describe/mod.rs (`describe_inner` happy path)
- src/prefetch/mod.rs (`prefetch `end-to-end command)

If you have any other suggestions/comments, please let know!