### PR TITLE
fix(prefetch): tokio panic issue

### DIFF
--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -68,14 +68,13 @@ pub fn describe_inner(accession: &str, skip: usize, limit: usize) -> Result<Desc
     Ok(stats)
 }
 
-pub fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
+pub async fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
     let accession = if !Path::new(&input.accession).exists() {
         eprintln!(
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let runtime = tokio::runtime::Runtime::new()?;
-        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
+        let url = identify_url(&input.accession, &input.options).await?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -68,13 +68,14 @@ pub fn describe_inner(accession: &str, skip: usize, limit: usize) -> Result<Desc
     Ok(stats)
 }
 
-pub async fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
+pub fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
     let accession = if !Path::new(&input.accession).exists() {
         eprintln!(
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let url = identify_url(&input.accession, &input.options).await?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -74,7 +74,8 @@ pub fn describe(input: &InputOptions, opts: &DescribeOptions) -> Result<()> {
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let url = identify_url(&input.accession, &input.options)?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -132,7 +132,7 @@ fn launch_threads(
     Ok(stats)
 }
 
-pub async fn dump(
+pub fn dump(
     input: &InputOptions,
     num_threads: u64,
     output_opts: &DumpOutput,
@@ -143,7 +143,8 @@ pub async fn dump(
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let url = identify_url(&input.accession, &input.options).await?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -143,7 +143,8 @@ pub fn dump(
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let url = identify_url(&input.accession, &input.options)?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -132,7 +132,7 @@ fn launch_threads(
     Ok(stats)
 }
 
-pub fn dump(
+pub async fn dump(
     input: &InputOptions,
     num_threads: u64,
     output_opts: &DumpOutput,
@@ -143,8 +143,7 @@ pub fn dump(
             "Identifying SRA data URL for Accession: {}",
             &input.accession
         );
-        let runtime = tokio::runtime::Runtime::new()?;
-        let url = runtime.block_on(identify_url(&input.accession, &input.options))?;
+        let url = identify_url(&input.accession, &input.options).await?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,17 +18,21 @@ use recode::recode;
 pub const BUFFER_SIZE: usize = 1024 * 1024;
 pub const RECORD_CAPACITY: usize = 1024;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let args = Cli::parse();
     match args.command {
-        cli::Command::Dump(args) => dump(
-            &args.input,
-            args.runtime.threads(),
-            &args.output,
-            args.filter,
-        ),
-        cli::Command::Recode(args) => recode(&args),
-        cli::Command::Describe(args) => describe(&args.input, &args.options),
-        cli::Command::Prefetch(args) => prefetch(&args.input, args.output.as_deref()),
+        cli::Command::Dump(args) => {
+            dump(
+                &args.input,
+                args.runtime.threads(),
+                &args.output,
+                args.filter,
+            )
+            .await
+        }
+        cli::Command::Recode(args) => recode(&args).await,
+        cli::Command::Describe(args) => describe(&args.input, &args.options).await,
+        cli::Command::Prefetch(args) => prefetch(&args.input, args.output.as_deref()).await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,9 @@ fn main() -> Result<()> {
         cli::Command::Recode(args) => recode(&args),
         cli::Command::Describe(args) => describe(&args.input, &args.options),
         cli::Command::Prefetch(args) => {
-            // Async is overkill for other commands,
-            // only prefetch gets full treatment
+            // Only prefetch is fully async. Other commands
+            // may use a runtime for fetching an SRA, but are
+            // otherwise synchronous
             let runtime = tokio::runtime::Runtime::new()?;
             runtime.block_on(prefetch(&args.input, args.output.as_deref()))
         }

--- a/src/recode/mod.rs
+++ b/src/recode/mod.rs
@@ -19,14 +19,15 @@ use crate::utils::get_num_records;
 
 const THREAD_UPDATE_INTERVAL: usize = 1024;
 
-pub async fn recode(args: &RecodeArgs) -> Result<()> {
+pub fn recode(args: &RecodeArgs) -> Result<()> {
     args.validate()?;
     let accession = if !Path::new(&args.input.accession).exists() {
         eprintln!(
             "Identifying SRA data URL for Accession: {}",
             &args.input.accession
         );
-        let url = identify_url(&args.input.accession, &args.input.options).await?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&args.input.accession, &args.input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/recode/mod.rs
+++ b/src/recode/mod.rs
@@ -19,15 +19,14 @@ use crate::utils::get_num_records;
 
 const THREAD_UPDATE_INTERVAL: usize = 1024;
 
-pub fn recode(args: &RecodeArgs) -> Result<()> {
+pub async fn recode(args: &RecodeArgs) -> Result<()> {
     args.validate()?;
     let accession = if !Path::new(&args.input.accession).exists() {
         eprintln!(
             "Identifying SRA data URL for Accession: {}",
             &args.input.accession
         );
-        let runtime = tokio::runtime::Runtime::new()?;
-        let url = runtime.block_on(identify_url(&args.input.accession, &args.input.options))?;
+        let url = identify_url(&args.input.accession, &args.input.options).await?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {

--- a/src/recode/mod.rs
+++ b/src/recode/mod.rs
@@ -26,7 +26,8 @@ pub fn recode(args: &RecodeArgs) -> Result<()> {
             "Identifying SRA data URL for Accession: {}",
             &args.input.accession
         );
-        let url = identify_url(&args.input.accession, &args.input.options)?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let url = runtime.block_on(identify_url(&args.input.accession, &args.input.options))?;
         eprintln!("Streaming SRA records from URL: {}", url);
         url
     } else {


### PR DESCRIPTION
Hi @noamteyssier, noticed a bug, so created a PR for it.

Running `prefetch` with multiple accessions has the following issue
```
xsra % cargo run -- prefetch SRR390728 SRR390729
warning: unused manifest key: alias
   Compiling xsra v0.2.20 (/Users/tim/Downloads/xsra)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.75s
     Running `target/debug/xsra prefetch SRR390728 SRR390729`
Identifying URLs for 2 accessions...
>> Identifying URL for accession: SRR390728
>> Identifying URL for accession: SRR390729

thread 'tokio-runtime-worker' panicked at /Users/tim/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
note: run with `RUST_BACKBACKTRACE=1` environment variable to display a backtrace
``` 

In order to resolve it, I changed the `prefetch` function to async. I also edited the functions calls in other files to use runtimes. I could have made them fully async, but I think this is overkill especially if they are local accessions that don't require it.

After adding the fix, it solves the previous panic issues
```
xsra % cargo run -- prefetch SRR390728 SRR390729
   Compiling xsra v0.2.20 (/Users/tim/Downloads/xsra)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.71s
     Running `target/debug/xsra prefetch SRR390728 SRR390729`
Identifying URLs for 2 accessions...
>> Identifying URL for accession: SRR390729
>> Identifying URL for accession: SRR390728
Warning: Lite quality not available for SRR390729, falling back to full quality
⠐ [00:00:23] [>---------------------------------------] 1.67 MiB/76.10 MiB (17m) SRR390728.lite.3
⠓ [00:00:22] [>---------------------------------------] 1.64 MiB/143.27 MiB (33m) SRR390729
```
