### PR TITLE
Change read name to {SRR}.{rid} or {SRR}.{rid}.{sid}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsra"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 license = "MIT"
 authors = ["Noam Teyssier <noam.teyssier@arcinstitute.org>"]

--- a/src/cli/dump.rs
+++ b/src/cli/dump.rs
@@ -50,6 +50,10 @@ pub struct DumpOutput {
     #[clap(short = 'p', long, default_value = "seg_")]
     pub prefix: String,
 
+    /// Include the segment ID in split files
+    #[clap(long, requires = "split")]
+    pub include_sid: bool,
+
     /// Compress output files
     ///
     /// [uncompressed, gzip, bgzip, zstd]
@@ -61,6 +65,15 @@ pub struct DumpOutput {
     /// By default empty files will be deleted
     #[clap(short = 'E', long)]
     pub keep_empty: bool,
+}
+impl DumpOutput {
+    pub fn include_sid(&self) -> bool {
+        if self.split {
+            self.include_sid
+        } else {
+            true
+        }
+    }
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -197,9 +197,6 @@ pub fn dump(
         .to_string();
     let accession_prefix = Some(accession_name);
 
-    // include the segment ID when interleaving (otherwise exclude it)
-    let include_sid = !output_opts.split;
-
     // Launch worker threads
     let stats = launch_threads(
         &accession,
@@ -210,7 +207,7 @@ pub fn dump(
         filter_opts,
         output_opts.format,
         accession_prefix,
-        include_sid,
+        output_opts.include_sid(),
     )?;
 
     // Remove empty files

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -89,10 +89,10 @@ fn launch_threads(
 
                     // Write the segment to the record set
                     write_segment_to_buffer_set(
-                        &mut local_buffers, 
-                        &segment, 
-                        format, 
-                        accession_prefix.as_ref().map(|(s, b)| (s.as_str(), *b))
+                        &mut local_buffers,
+                        &segment,
+                        format,
+                        accession_prefix.as_ref().map(|(s, b)| (s.as_str(), *b)),
                     )?;
 
                     if counts.len() == 1 {
@@ -194,7 +194,7 @@ pub fn dump(
         .unwrap_or(&input.accession)
         .to_string();
     let accession_prefix = Some((accession_name, !output_opts.split));
-    
+
     // Launch worker threads
     let stats = launch_threads(
         &accession,

--- a/src/dump/utils.rs
+++ b/src/dump/utils.rs
@@ -9,13 +9,14 @@ pub fn write_segment_to_buffer_set(
     buffers: &mut [Vec<u8>],
     segment: &Segment<'_>,
     format: OutputFormat,
+    accession_prefix: Option<(&str, bool)>,
 ) -> Result<()> {
     if buffers.len() == 1 {
         // Interleaved output - single output handle
         let buffer = &mut buffers[0];
         match format {
-            OutputFormat::Fasta => write_fasta(buffer, segment)?,
-            OutputFormat::Fastq => write_fastq(buffer, segment)?,
+            OutputFormat::Fasta => write_fasta(buffer, segment, accession_prefix)?,
+            OutputFormat::Fastq => write_fastq(buffer, segment, accession_prefix)?,
         }
         Ok(())
     } else {
@@ -28,15 +29,24 @@ pub fn write_segment_to_buffer_set(
         let seg_id = segment.sid();
         let buffer = &mut buffers[seg_id];
         match format {
-            OutputFormat::Fasta => write_fasta(buffer, segment)?,
-            OutputFormat::Fastq => write_fastq(buffer, segment)?,
+            OutputFormat::Fasta => write_fasta(buffer, segment, accession_prefix)?,
+            OutputFormat::Fastq => write_fastq(buffer, segment, accession_prefix)?,
         }
         Ok(())
     }
 }
 
-pub fn write_fastq<W: Write>(wtr: &mut W, segment: &Segment<'_>) -> Result<()> {
-    writeln!(wtr, "@{}.{}", segment.rid(), segment.sid())?;
+pub fn write_fastq<W: Write>(wtr: &mut W, segment: &Segment<'_>, accession_prefix: Option<(&str, bool)>) -> Result<()> {
+    match accession_prefix {
+        Some((prefix, include_sid)) => {
+            if include_sid {
+                writeln!(wtr, "@{}.{}.{}", prefix, segment.rid(), segment.sid())?;
+            } else {
+                writeln!(wtr, "@{}.{}", prefix, segment.rid())?;
+            }
+        }
+        None => writeln!(wtr, "@{}.{}", segment.rid(), segment.sid())?,
+    }
     wtr.write_all(segment.seq())?;
     writeln!(wtr, "\n+")?;
     wtr.write_all(segment.qual())?;
@@ -44,8 +54,17 @@ pub fn write_fastq<W: Write>(wtr: &mut W, segment: &Segment<'_>) -> Result<()> {
     Ok(())
 }
 
-pub fn write_fasta<W: Write>(wtr: &mut W, segment: &Segment<'_>) -> Result<()> {
-    writeln!(wtr, ">{}.{}", segment.rid(), segment.sid())?;
+pub fn write_fasta<W: Write>(wtr: &mut W, segment: &Segment<'_>, accession_prefix: Option<(&str, bool)>) -> Result<()> {
+    match accession_prefix {
+        Some((prefix, include_sid)) => {
+            if include_sid {
+                writeln!(wtr, ">{}.{}.{}", prefix, segment.rid(), segment.sid())?;
+            } else {
+                writeln!(wtr, ">{}.{}", prefix, segment.rid())?;
+            }
+        }
+        None => writeln!(wtr, ">{}.{}", segment.rid(), segment.sid())?,
+    }
     wtr.write_all(segment.seq())?;
     writeln!(wtr)?;
     Ok(())

--- a/src/dump/utils.rs
+++ b/src/dump/utils.rs
@@ -36,7 +36,11 @@ pub fn write_segment_to_buffer_set(
     }
 }
 
-pub fn write_fastq<W: Write>(wtr: &mut W, segment: &Segment<'_>, accession_prefix: Option<(&str, bool)>) -> Result<()> {
+pub fn write_fastq<W: Write>(
+    wtr: &mut W,
+    segment: &Segment<'_>,
+    accession_prefix: Option<(&str, bool)>,
+) -> Result<()> {
     match accession_prefix {
         Some((prefix, include_sid)) => {
             if include_sid {
@@ -54,7 +58,11 @@ pub fn write_fastq<W: Write>(wtr: &mut W, segment: &Segment<'_>, accession_prefi
     Ok(())
 }
 
-pub fn write_fasta<W: Write>(wtr: &mut W, segment: &Segment<'_>, accession_prefix: Option<(&str, bool)>) -> Result<()> {
+pub fn write_fasta<W: Write>(
+    wtr: &mut W,
+    segment: &Segment<'_>,
+    accession_prefix: Option<(&str, bool)>,
+) -> Result<()> {
     match accession_prefix {
         Some((prefix, include_sid)) => {
             if include_sid {

--- a/tests/dump.rs
+++ b/tests/dump.rs
@@ -70,6 +70,7 @@ fn test_split_file_dump() -> Result<()> {
         named_pipes: false,
         split: true,
         keep_empty: false,
+        include_sid: false,
     };
 
     let filter_opts = FilterOptions {
@@ -145,6 +146,7 @@ fn test_empty_file_removal() -> Result<()> {
         named_pipes: false,
         split: true,
         keep_empty: false,
+        include_sid: false,
     };
 
     let filter_opts = FilterOptions {


### PR DESCRIPTION
Hi @noamteyssier 

Thanks for making this awesome package!

This is a small change in how the reads are named that I found useful for some stuff I've been working on, so I thought I'd open a PR in case you're interested to add this change. Some tools (for example, cellranger) require that read names are matching across the different output files (R1, R2, etc.).

Here I modified the fastq and fasta output so that the reads are named as:

* with `--split`: {SRR}.{spot_number}
* without `--split`: {SRR}.{spot_number}.{segment_number} (keep the segment number for interleaved fastq output)
